### PR TITLE
feat: disable no-use-before-define

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,5 +66,6 @@ module.exports = {
 
     // typescript
     '@typescript-eslint/explicit-function-return-type': 0,
+    '@typescript-eslint/no-use-before-define': 0,
   },
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-tnez",
-  "version": "1.1.6",
+  "version": "1.2.0",
   "description": "personal eslint config",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Disable `@typescript-eslint/no-use-before-define` because I like to define helper functions below the main functions in order to "keep the important things on top".

---
closes #1