### PR TITLE
chore(deps): update peer dependency eslint-plugin-jest

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,8 +39,7 @@ module.exports = {
     'jest/no-jest-import': 'error',
     'jest/no-large-snapshots': ['warn', { maxSize: 300 }],
     'jest/prefer-strict-equal': 'warn',
-    'jest/prefer-to-be-null': 'error',
-    'jest/prefer-to-be-undefined': 'error',
+    'jest/prefer-to-be': 'error',
     'jest/prefer-to-have-length': 'error',
     'jest/valid-expect': 'error',
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-tnez",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "description": "personal eslint config",
   "repository": {
     "type": "git",
@@ -28,7 +28,7 @@
     "@typescript-eslint/parser": ">= 2.6.1",
     "eslint": ">= 6.6.0",
     "eslint-config-prettier": ">= 6.5.0",
-    "eslint-plugin-jest": ">= 23.0.3",
+    "eslint-plugin-jest": ">= 26.0.0",
     "eslint-plugin-prettier": ">= 3.1.1",
     "eslint-plugin-react": ">= 7.16.0",
     "prettier": ">= 1.19.0"


### PR DESCRIPTION
BREAKING CHANGE!!!

Update peer dependency requirements for `eslint-plugin-jest` and along
with it came some changes to rule names.
